### PR TITLE
Add Discriminator to Swirl

### DIFF
--- a/tornado_swirl/_parser_model.py
+++ b/tornado_swirl/_parser_model.py
@@ -31,6 +31,7 @@ class SchemaSpec(object):
         self.properties = {}
         self.example = None
         self.examples = None
+        self.discriminator = None
 
 
 class Param(object):

--- a/tornado_swirl/docparser.py
+++ b/tornado_swirl/docparser.py
@@ -337,6 +337,8 @@ def _transition_processbuffer_discriminator(fsm_obj):
 
 def _is_generic_line(line):
     line = line.strip()
+    if _DISCRIMINATOR_HEADER_REGEX.match(line):
+        return False
     if _SECTION_HEADER_REGEX.match(line):
         return False
     if _DEPRECATED_HEADER_REGEX.match(line):

--- a/tornado_swirl/docparser.py
+++ b/tornado_swirl/docparser.py
@@ -22,7 +22,6 @@ _PROPERTY_HEADERS = 'properties'
 _TAGS_HEADERS = 'tags'
 _DEPRECATED_HEADERS = 'deprecated'
 _SECURITY_HEADERS = 'security'
-_PARENT_HEADERS = 'parent'
 
 # data processors
 # objects

--- a/tornado_swirl/docparser.py
+++ b/tornado_swirl/docparser.py
@@ -255,7 +255,7 @@ _ALL_HEADERS_REGEX = re.compile("^(" + _ALL_HEADERS + ")$", re.IGNORECASE)
 _SECTION_HEADER_REGEX = re.compile(r"^([\w ]+):$")
 _DEPRECATED_HEADER_REGEX = re.compile(
     r"^(deprecated|\[deprecated\])$", re.IGNORECASE)
-_DISCRIMINATOR_HEADER_REGEX = re.compile(r"^(discriminator:) ?([\w]+)")
+_DISCRIMINATOR_HEADER_REGEX = re.compile(r"^(discriminator:) ?([\w]+)", re.IGNORECASE)
 
 S_START = 0
 S_SUMMARY = 1
@@ -397,6 +397,8 @@ FSM_MAP = (
      'condition': _is_section_header, 'callback': _transition_processbuffer_new_section},
     {'src': S_SECTION, 'dst': S_END,
      'condition': _is_end, 'callback': _transition_processbuffer},
+    {'src': S_SECTION, 'dst': S_BLANK,
+     'condition': _is_blank_line, 'callback': _transition_processbuffer},
     {'src': S_START, 'dst': S_END, 'condition': _is_end,
      'callback': _transition_processbuffer},
     {'src': S_BLANK, 'dst': S_END, 'condition': _is_end,
@@ -411,6 +413,8 @@ FSM_MAP = (
      'callback': _transition_blank},
     {'src': S_DISCRIMINATOR, 'dst': S_SECTION, 'condition': _is_section_header,
      'callback': _transition_section},
+    {'src': S_DISCRIMINATOR, 'dst': S_BLANK, 'condition': _is_blank_line,
+     'callback': _transition_blank},
     {'src': S_SECTION, 'dst': S_DISCRIMINATOR, 'condition': _is_discriminator,
      'callback': _transition_processbuffer_discriminator}
 )

--- a/tornado_swirl/views.py
+++ b/tornado_swirl/views.py
@@ -147,7 +147,7 @@ class SwaggerApiHandler(tornado.web.RequestHandler):
             obj['description'] = specs[0].description or specs[0].summary
 
             if specs[0].discriminator:
-                obj['discriminator'] = specs[0].discriminator
+                obj['discriminator'] = {"propertyName": specs[0].discriminator}
 
             if required:
                 obj.update({"required": required})

--- a/tornado_swirl/views.py
+++ b/tornado_swirl/views.py
@@ -145,6 +145,10 @@ class SwaggerApiHandler(tornado.web.RequestHandler):
             required = [name for name, _, req in props if req]
             obj = {"type": "object"}
             obj['description'] = specs[0].description or specs[0].summary
+
+            if specs[0].discriminator:
+                obj['discriminator'] = specs[0].discriminator
+
             if required:
                 obj.update({"required": required})
 


### PR DESCRIPTION
Adds support for a single line discriminator. I can expand / add whatever necessary fields we need going forward. To match what's generated in java you would add `Discriminator: className` to the docstring of the class you want to generate for. The implementation of swirl's docstring parser is using a finite state machine and i basically added a new `S_DISCRIMINATOR` state along with the relevant transitions.